### PR TITLE
Spec cleanup

### DIFF
--- a/LanguageSpec.md
+++ b/LanguageSpec.md
@@ -369,6 +369,12 @@ b = a; // error: "a" is not defined yet
 a = 1;
 ```
 
+It is allowed to have type after variable definition, but that type doesn't define variable's type, it is for type conversion. Example:
+
+```
+x : int[] = 3;  // x = {3}
+```
+
 ### Scope
 
 The scope of a defined variable in DesignScript is limited to a block or a function where it is defined and is not visible in any nested imperative block or any other function.

--- a/LanguageSpec.md
+++ b/LanguageSpec.md
@@ -345,7 +345,7 @@ a = 1;
 
 ### Scope
 
-The scope of a defined variable in DesignScript is limited to a block or a function where it is defined and is not extended to any nested block or any other function. A block could be the top level block or an imperative block.
+The scope of a defined variable in DesignScript is limited to a block or a function where it is defined and is not visible in any nested imperative block or any other function.
 
 To pass a variable to a nested imperative block, the variable should be explicitly captured in block's capture list. To pass a variable to a function, the variable should be passed as an argument. In either case, the variable will be copied to maintain its immutability.
 
@@ -365,6 +365,15 @@ def foo(x) {
 [Imperative](x) {
     x = 3;          // "x" is not the "x" defined in outer block.
                     // OK to change its value
+
+    if (true) {
+        y = x + 100;// OK, "x" is visible here
+        if (true) {
+            z = 200;
+        }
+    }
+
+    z = y;          // "y" is not defined
 }
 ```
 

--- a/LanguageSpec.md
+++ b/LanguageSpec.md
@@ -818,7 +818,7 @@ def sum(x)
 
 ### Replication and replication guide
 
-Replication is a way to express iteration in associative language block. It applies to a function call when the rank of input arguments exceeds the rank of parameters. In other words, a function may be called multiple times in replication, and the return value from each function call will be aggregated and returned as a list.
+Replication is a way to express iteration. It applies to a function call when the rank of input arguments exceeds the rank of parameters. In other words, a function may be called multiple times in replication, and the return value from each function call will be aggregated and returned as a list.
 
 There are two kinds of replication:
 

--- a/LanguageSpec.md
+++ b/LanguageSpec.md
@@ -187,7 +187,7 @@ number[][]   // a number list whose rank is 2
 number[]..[] // a number list with arbitrary rank
 ```
 
-The rank of type decides how do [replication ](#heading=h.f51u2x6ertfi)and [replication guide](#heading=h.f51u2x6ertfi) work in function dispatch.
+The rank of type decides how replication and replication guide work in function dispatch.
 
 #### List as dictionary
 
@@ -203,7 +203,7 @@ length = len(x);    // length == 6;
 v = y[5];           // v == "foo"
 ```
 
-When a dictionary is used in "in" clause of “[for](#heading=h.wl3kjkvppdmk)” loop, it returns all values associated with keys.
+When a dictionary is used in `in` clause of `for` loop, it returns all values associated with keys.
 
 ### Type conversion rules
 
@@ -390,7 +390,7 @@ The return type of function is optional. By default the return type is var. If t
 
 Function must be defined in the global scope.
 
-For parameters, if their types are not specified, by default is var. The type of parameters should be carefully specified so that [replication and replication guide](#heading=h.f51u2x6ertfi) will work as desired. For example, if a parameter’s type is `var[]..[]` ([arbitrary rank](#heading=h.x5qwed3vbjgx)), it means no replication on this parameter.
+For parameters, if their types are not specified, by default is var. The type of parameters should be carefully specified so that replication and replication guide will work as desired. For example, if a parameter’s type is `var[]..[]` (arbitrary rank), it means no replication on this parameter.
 
 For example:
 
@@ -513,26 +513,13 @@ r = x ? y : z;  // replicates, r = {“foo”, “dang”, “qux”}
 
 ### List access expression
 
-List access expression is of the form
+List access expression is a right-value expression and is of the form
 
 ```
-a[x]
+r = a[x];
 ```
 
-"x" could be integer value or a key of any kind of types (if “a” is a [list](#heading=h.x6hkvoejht8r)).
-
-The following rules apply:
-
-* If it is just getting value, if "a" is not a list, or the length of “a” is less than “x”, or the rank of “a” is less than the number of indexer, for example the rank of “a” is 2 but the expression is a[x][y][z], there will be a “IndexOutOfRange” warning and null will be returned.
-
-* If it is assigning a value to the list,  if "a" is not a list, or the length of “a” is less than “x”, or the rank of “a” is less than the number of indexer, “a” will be extended or its dimension will promoted so that it is able to accommodate the value. For example,
-
-```
-a = 1;
-a[1] = 2;      // "a" will be promoted, a = {1, 2} now
-a[3] = 3;      // “a” will be extended, a = {1, 2, null, 3} now
-a[0][1] = 3;   // “a” will be promoted, a = {{1, 3}, 2, null, 3} now
-```
+where `x` could be any kind of value (if `a` is a list). It is not allowed to change the value of an element in a list in-place. Instead, use built-in function `Set()`.
 
 ### Operators
 
@@ -657,17 +644,17 @@ Expression statements are expressions without assignment.
 Assignment = Expression "=" ((Expression “;”) | LanguageBlock)
 ```
 
-The left hand side of "=" should be assignable. Typically, it is [member access expression](#heading=h.rf6u7s9js69k) or [array access expression](#heading=h.7iw1e1npd4z) or variable. If the left hand side is a variable which hasn’t been defined before, the assignment statement will define this variable.
+The left hand side of "=" should be a variable.
 
 ### Flow statements
 
 Flow statements change the execution flow of the program. A flow statement is one of the followings:
 
-1. A [return ](#heading=h.xw8lqigquohf)statement.
+1. A `return` statement.
 
-2. A [break ](#heading=h.wf15sn8vv9wg)statement in the block of [for](#heading=h.wl3kjkvppdmk) or [while ](#heading=h.55s0w9n1v8k2)statement in imperative block.
+2. A `break` statement in the block of `for` or `while` statement in imperative block.
 
-3. A [continue ](#heading=h.4yawi3g9ookh)statement in the block of [for](#heading=h.wl3kjkvppdmk) or [while ](#heading=h.55s0w9n1v8k2)statement in imperative block.
+3. A `continue` statement in the block of `for` or `while` statement in imperative block.
 
 ### Return statement
 
@@ -675,7 +662,7 @@ Flow statements change the execution flow of the program. A flow statement is on
 ReturnStatement = "return" Expression “;”
 ```
 
-A "return" statement terminates the execution of the innermost function and returns to its caller, or terminates the innermost imperative block, and returns to the upper-level language block or function.
+A `return` statement terminates the execution of the innermost function and returns to its caller, or terminates the innermost imperative block, and returns to the upper-level language block or function.
 
 ### Break statement
 
@@ -683,7 +670,7 @@ A "return" statement terminates the execution of the innermost function and retu
 BreakStatement = "break" “;”
 ```
 
-A "break" statement terminates the execution of the innermost “[for](#heading=h.wl3kjkvppdmk)” loop or “[while](#heading=h.55s0w9n1v8k2)” loop.
+A `break` statement terminates the execution of the innermost `for` loop or `while` loop.
 
 ### Continue statement
 
@@ -691,11 +678,11 @@ A "break" statement terminates the execution of the innermost “[for](#heading=
 ContinueStatement = "continue" “;”
 ```
 
-A "continue" statement begins the next iteration of the innermost “[for](#heading=h.wl3kjkvppdmk)” loop or “[while](#heading=h.55s0w9n1v8k2)” loop.
+A `continue` statement begins the next iteration of the innermost `for` loop or `while` loop.
 
 ### If statement
 
-"if" statements specify the conditional execution of multiple branches based on the boolean value of each conditional expression. “if” statements are only valid in imperative block.
+`if` statements specify the conditional execution of multiple branches based on the boolean value of each conditional expression. “if” statements are only valid in imperative block.
 
 ```
 IfStatement =
@@ -703,7 +690,6 @@ IfStatement =
     { “elseif” “(” Expression “)” StatementBlock }
     [ “else” StatementBlock ]
 ```
-
 
 For example:
 
@@ -725,12 +711,11 @@ else {
 
 ### While statement
 
-A "while" statement repeatedly executes a block until the condition becomes false. “while” statements are only valid in imperative block.
+A `while` statement repeatedly executes a block until the condition becomes false. `while` statements are only valid in imperative block.
 
 ```
 WhileStatement = "while" “(” Expression “)” StatementBlock
 ```
-
 
 Example:
 
@@ -747,7 +732,7 @@ while (x < 10)
 
 ### For statements
 
-"for" iterates all values in “in” clause and assigns the value to the loop variable. The expression in “in” clause should return a list; if it is a singleton, it is a single statement evaluation. “for” statements are only valid in imperative block.
+`for` iterates all values in `in` clause and assigns the value to the loop variable. The expression in `in` clause should return a list; if it is a singleton, it is a single statement evaluation. `for` statements are only valid in imperative block.
 
 ```
 ForStatement = "for" “(” Identifier “in” Expression “)” StatementBlock

--- a/LanguageSpec.md
+++ b/LanguageSpec.md
@@ -930,6 +930,7 @@ r = foo(xs<1L><1>, ys<1L>);
 // }
 //
 // And the final result is {{"1a", "1b"}, {"2a", "2b"}}
+```
 
 ### Function dispatch for replication
 

--- a/LanguageSpec.md
+++ b/LanguageSpec.md
@@ -6,7 +6,7 @@ This is the specification for DesignScript programming language. DesignScript is
 
 The grammar in this specification is in Extended Backus-Naur Form (EBNF)
 
-This document doesn’t contain information about APIs and Foreign Function Interface (FFI). The latter is implementation dependent. 
+This document doesn’t contain information about APIs and Foreign Function Interface (FFI). The latter is implementation dependent.
 
 ## Lexical elements
 
@@ -191,20 +191,21 @@ The rank of type decides how do [replication ](#heading=h.f51u2x6ertfi)and [repl
 
 #### List as dictionary
 
-List in DesignScript is just a special case of dictionary whose keys are continuous integers start from 0. We could use built-in function `Set()` to set value for any kind of key. For example:
+List in DesignScript is just a special case of dictionary whose keys are continuous integers start from 0. We could use built-in function `Set()` to set value for any kind of key.
+
 Lists are dynamic. It is possible to index into any location of the list. If setting value to an index which is beyond the length of list, list will be automatically expanded. For example,
 
 ```
 x = {1, 2, 3};
 
 y = Set(x, 5, "foo")
-length = len(x);    // length == 3;
+length = len(x);    // length == 6;
 v = y[5];           // v == "foo"
 ```
 
 When a dictionary is used in "in" clause of “[for](#heading=h.wl3kjkvppdmk)” loop, it returns all values associated with keys.
 
-### Type conversion rules(TBD)
+### Type conversion rules
 
 Following implicit type conversion rules specify the result of converting one type to another:
 
@@ -219,7 +220,7 @@ Following implicit type conversion rules specify the result of converting one ty
     <td>number</td>
     <td>bool</td>
     <td>string</td>
-    <td>ffi type</td>
+    <td>FFI type</td>
   </tr>
   <tr>
     <td>var</td>
@@ -233,7 +234,7 @@ Following implicit type conversion rules specify the result of converting one ty
     <td>number</td>
     <td>yes</td>
     <td>yes</td>
-    <td>x != 0 && x != NaN</td>
+    <td>no</td>
     <td>no</td>
     <td>no</td>
   </tr>
@@ -242,24 +243,24 @@ Following implicit type conversion rules specify the result of converting one ty
     <td>yes</td>
     <td>no</td>
     <td>yes</td>
-    <td>yes</td>
+    <td>no</td>
     <td>no</td>
   </tr>
   <tr>
     <td>string</td>
     <td>yes</td>
     <td>no</td>
-    <td>x != ""</td>
+    <td>no</td>
     <td>yes</td>
     <td>no</td>
   </tr>
   <tr>
-    <td>ffi type</td>
+    <td>FFI type</td>
     <td>yes</td>
     <td>no</td>
-    <td>x != ""</td>
-    <td>yes</td>
     <td>no</td>
+    <td>no</td>
+    <td>yes</td>
   </tr>
 </table>
 
@@ -273,7 +274,7 @@ Following implicit type conversion rules specify the result of converting one ty
     <td>number[]</td>
     <td>bool[]</td>
     <td>string[]</td>
-    <td>ffi type []</td>
+    <td>FFI type []</td>
   </tr>
   <tr>
     <td>var</td>
@@ -287,7 +288,7 @@ Following implicit type conversion rules specify the result of converting one ty
     <td>number</td>
     <td>yes</td>
     <td>yes</td>
-    <td>x != 0 && x != NaN</td>
+    <td>no</td>
     <td>no</td>
     <td>no</td>
   </tr>
@@ -296,87 +297,43 @@ Following implicit type conversion rules specify the result of converting one ty
     <td>yes</td>
     <td>no</td>
     <td>yes</td>
-    <td>yes</td>
+    <td>no</td>
     <td>no</td>
   </tr>
   <tr>
     <td>string</td>
     <td>yes</td>
     <td>no</td>
-    <td>x != ""</td>
+    <td>no</td>
     <td>yes</td>
     <td>no</td>
   </tr>
   <tr>
-    <td>ffi type</td>
-    <td>na</td>
-    <td>na</td>
-    <td>na</td>
-    <td>na</td>
-    <td>na</td>
-  </tr>
-</table>
-
-#### Rank demotion
-
-<table>
-  <tr>
-    <td>From To</td>
-    <td>var</td>
-    <td>number</td>
-    <td>bool</td>
-    <td>string</td>
-    <td>ffi type</td>
-  </tr>
-  <tr>
-    <td>var[]</td>
+    <td>FFI type</td>
     <td>yes</td>
     <td>no</td>
     <td>no</td>
-    <td>no</td>
-    <td>no</td>
-  </tr>
-  <tr>
-    <td>number[]</td>
-    <td>yes</td>
-    <td>yes</td>
-    <td>x != 0</td>
-    <td>no</td>
-    <td>no</td>
-  </tr>
-  <tr>
-    <td>bool[]</td>
-    <td>yes</td>
-    <td>no</td>
-    <td>yes</td>
-    <td>yes</td>
-    <td>no</td>
-  </tr>
-  <tr>
-    <td>string[]</td>
-    <td>yes</td>
-    <td>no</td>
-    <td>x != ""</td>
-    <td>yes</td>
-    <td>no</td>
-  </tr>
-  <tr>
-    <td>ffi type[]</td>
-    <td>yes</td>
-    <td>no</td>
-    <td>x != null</td>
     <td>no</td>
     <td>Covariant</td>
-	</tr>
+  </tr>
 </table>
 
 ## Variables
 
-A variable is storage location for a value. As DesignScript is dynamic, it is free to assign any kind of value to a variable. Unlike other languages, variable in DesignScript is immutable. That is, a variable is only allowed to be assigned once. For example,
+A variable is storage location for a value. As DesignScript is dynamic, it is free to assign any kind of value to a variable. Variable in global scope is immutable. That is, a variable is only allowed to be assigned once. For example,
 
 ```
 a = 1;
 a = 2; // error: double assignment
+```
+
+But a variable is mutable in imperative block. For example,
+```
+[Imperative]
+{
+    x = 1;
+    x = 2; // OK
+}
 ```
 
 All variables should be defined before being used. For example,
@@ -388,7 +345,7 @@ a = 1;
 
 ### Scope
 
-Unlike block scope (NOTE:  https://en.wikipedia.org/wiki/Scope_(computer_science)#Block_scope) in most programming language, DesignScript only looks up variables defined in current block, and a block could be either function or language block.
+Unlike block scope (NOTE:  https://en.wikipedia.org/wiki/Scope_(computer_science)#Block_scope) in most programming language, DesignScript only looks up variables defined in current block, and a block could be either function or imperative block.
 
 ```
 x = 1;
@@ -397,13 +354,12 @@ y = 2;
 def foo(x) {
     z = 3;          // "z" is local variable
     return = x + y; // “x” is parameter
-                    // waring: “y” is not defined
+                    // error: “y” is not defined
 }
 
 [Imperative](x) {
-    x = 3;              // error: "x" is not allowed to be assigned twice
-    n = 4;              // the VM ensures “m” finally is 4
-    return = x + y + m; // error: "y" is not defined yet
+    x = 3;          // "x" is not the "x" defined outside.
+                    // OK to change its value
 }
 ```
 
@@ -436,7 +392,7 @@ Example:
 ```
 def foo:var(x:number[]..[], y:number = 3)
 {
-    return = x + y;
+    return x + y;
 }
 ```
 
@@ -462,20 +418,21 @@ def bar(x = 1, y, z = 2)
 
 #### Function overloads
 
-Like most dynamic languages, DesignScript doesn't supports function overload.
+Like most dynamic languages, DesignScript doesn't supports function overload. See FFI.
 
 ## Expressions
 
 ### List creation expression
 
 ```
-ListCreationExpression = "{“ [Expression { “," Expression } ] “}”
+ListCreationExpression = "{“ [[Expression ":"] Expression { “," [Expression ":"] Expression } ] “}”
 ```
 
 List creation expression is to create a list. Example:
 
 ```
 x = {{1, 2, 3}, null, {true, false}, "DesignScript"};
+y = {0:"foo", 1:"bar", "qux":"quz"};
 ```
 
 ### Range expression
@@ -551,18 +508,6 @@ z = {“ding”, “dang”, “dong”};
 r = x ? y : z;  // replicates, r = {“foo”, “dang”, “qux”}
 ```
 
-
-### Member access expression
-
-Member access expression is of the form
-
-```
-x.y.z
-```
-
-
-"y" and “z” could be properties, or member functions. If they are not accessible, null will be returned.
-
 ### List access expression
 
 List access expression is of the form
@@ -608,7 +553,6 @@ The following operators are supported in DesignScript:
 !         Logical not
 -         Negate
 ```
-
 
 All operators support replication. Except unary operator "!", all other operators also support replication guide. That is, the operands could be appended replication guides.
 
@@ -719,25 +663,23 @@ Flow statements change the execution flow of the program. A flow statement is on
 
 1. A [return ](#heading=h.xw8lqigquohf)statement.
 
-2. A [break ](#heading=h.wf15sn8vv9wg)statement in the block of [for](#heading=h.wl3kjkvppdmk) or [while ](#heading=h.55s0w9n1v8k2)statement in [imperative language block](#heading=h.271e3yqazhhe).
+2. A [break ](#heading=h.wf15sn8vv9wg)statement in the block of [for](#heading=h.wl3kjkvppdmk) or [while ](#heading=h.55s0w9n1v8k2)statement in imperative block.
 
-3. A [continue ](#heading=h.4yawi3g9ookh)statement in the block of [for](#heading=h.wl3kjkvppdmk) or [while ](#heading=h.55s0w9n1v8k2)statement in [imperative language block](#heading=h.271e3yqazhhe).
+3. A [continue ](#heading=h.4yawi3g9ookh)statement in the block of [for](#heading=h.wl3kjkvppdmk) or [while ](#heading=h.55s0w9n1v8k2)statement in imperative block.
 
 ### Return statement
 
 ```
-ReturnStatement = "return" “=” Expression “;”
+ReturnStatement = "return" Expression “;”
 ```
 
-
-A "return" statement terminates the execution of the innermost function and returns to its caller, or terminates the innermost[ imperative language block](#heading=h.271e3yqazhhe), and returns to the upper-level language block or function.
+A "return" statement terminates the execution of the innermost function and returns to its caller, or terminates the innermost imperative block, and returns to the upper-level language block or function.
 
 ### Break statement
 
 ```
 BreakStatement = "break" “;”
 ```
-
 
 A "break" statement terminates the execution of the innermost “[for](#heading=h.wl3kjkvppdmk)” loop or “[while](#heading=h.55s0w9n1v8k2)” loop.
 
@@ -747,12 +689,11 @@ A "break" statement terminates the execution of the innermost “[for](#heading=
 ContinueStatement = "continue" “;”
 ```
 
-
 A "continue" statement begins the next iteration of the innermost “[for](#heading=h.wl3kjkvppdmk)” loop or “[while](#heading=h.55s0w9n1v8k2)” loop.
 
 ### If statement
 
-"if" statements specify the conditional execution of multiple branches based on the boolean value of each conditional expression. “if” statements are only valid in [imperative language block](#heading=h.271e3yqazhhe).  
+"if" statements specify the conditional execution of multiple branches based on the boolean value of each conditional expression. “if” statements are only valid in imperative block.
 
 ```
 IfStatement =
@@ -782,7 +723,7 @@ else {
 
 ### While statement
 
-A "while" statement repeatedly executes a block until the condition becomes false. “while” statements are only valid in [imperative language block](#heading=h.271e3yqazhhe).
+A "while" statement repeatedly executes a block until the condition becomes false. “while” statements are only valid in imperative block.
 
 ```
 WhileStatement = "while" “(” Expression “)” StatementBlock
@@ -804,7 +745,7 @@ while (x < 10)
 
 ### For statements
 
-"for" iterates all values in “in” clause and assigns the value to the loop variable. The expression in “in” clause should return a list; if it is a singleton, it is a single statement evaluation. “for” statements are only valid in [imperative language block](#heading=h.271e3yqazhhe).
+"for" iterates all values in “in” clause and assigns the value to the loop variable. The expression in “in” clause should return a list; if it is a singleton, it is a single statement evaluation. “for” statements are only valid in imperative block.
 
 ```
 ForStatement = "for" “(” Identifier “in” Expression “)” StatementBlock
@@ -823,27 +764,21 @@ for (x in 1..10)
 
 ## Language blocks
 
-### Default associative language block
+### Default block
 
-By default, all statements are in a default top [associative language block](#heading=h.4hx9oahduirh), so [associative update](#heading=h.1vv0i14ck6wu) is enabled by default.
+By default, all statements are in a default top block. No return statement is allowed in top block. The execution order of statements in top block is *not* guaranteed to be executed in sequential.
 
-Not like nested language block, there is no return statement in top language block: all statements will be executed sequentially to the last one.
+### Imperative block
 
-### Imperative language block
+Imperative block provides a convenient way to use imperative semantics. All statements in imperative block will be executed sequentially. Variables defined in imperative block is mutable. It is not allowed to nest an imperative block inside the other imperative block.
 
-Imperative language block provides a convenient way to use imperative semantics. Similar to nested associative language block, imperative language block executes all statements sequentially unless a statement is a [return statement](#heading=h.bhwa3rqti3pb) to return a value. Imperative language block can only be defined in the other associative language block, including the top associative language block.
-
-The key differences between associative language block and imperative language block are:
-
-* "if", “for” and “while” statements are only available in imperative language blocks. 
-
-Example:
+Examples of imperative block:
 
 ```
 x = 1;
 
-// define an imperative language block in the top associative language block
-y = [Imperative]
+// define an imperative block
+y = [Imperative](x)
 {
     if (x > 10) {
         return = 3;
@@ -858,9 +793,8 @@ y = [Imperative]
 
 def sum(x)
 {
-    // define an imperative language block inside a function, which is in global
-    // associative language block
-    return = [Imperative]
+    // define an imperative block inside a function
+    return = [Imperative](x)
     {
         s = 0;
         for (i in 1..x)
@@ -873,7 +807,7 @@ def sum(x)
 
 [Imperative]
 {
-    // invalid imperative language block
+    // invalid nested imperative block
     [Imperative]
     {
     }
@@ -898,7 +832,7 @@ There are two kinds of replication:
 
 to specify the longest approach.
 
-* Cartesian replication: it is equivalent to nested loop in imperative language. For example, for input arguments {x1, x2, ..., xn} and {y1, y2, ..., yn}, when calling function f() with cartesian replication and the cartesian indices are {0, 1}, which means the iteration over the first argument is the first loop, and the iteration over the second argument is the nested loop; it is equivalent to {f(x1, y1}, f(x1, y2), ..., f(x1, yn}, f(x2, y1), f(x2, y2), ..., f(x2, yn), ..., f(xn, y1), f(xn, y2), ..., f(xn, yn)}.
+* Cartesian replication: it is equivalent to nested loop in imperative block. For example, for input arguments {x1, x2, ..., xn} and {y1, y2, ..., yn}, when calling function f() with cartesian replication and the cartesian indices are {0, 1}, which means the iteration over the first argument is the first loop, and the iteration over the second argument is the nested loop; it is equivalent to {f(x1, y1}, f(x1, y2), ..., f(x1, yn}, f(x2, y1), f(x2, y2), ..., f(x2, yn), ..., f(xn, y1), f(xn, y2), ..., f(xn, yn)}.
 
 Replication guide is used to specify the order of cartesian replication indices; the lower replication guide, the outer loop. If two replication guides are the same value, zip replication will be applied.
 
@@ -964,8 +898,6 @@ Besides replication for explicit function call, replication and replication guid
 3. Inline conditional expression in the form of "xs ? ys : zs" where “xs”, “ys” and “zs” are lists.
 
 4. Array indexing. For example, xs[ys] where ys is a list. Replication could apply to array indexing on the both sides of assignment expression. Note replication does not apply to multiple indices.
-
-5. Member access expression. For example, xs.foo(ys) where xs and ys are lists. Replication guide could be applied to objects and arguments. If xs is a list, xs should be a homogeneous list, i.e., all elements in xs are of the same type.
 
 ### Function dispatch rule for replication and replication guide
 

--- a/LanguageSpec.md
+++ b/LanguageSpec.md
@@ -171,15 +171,15 @@ The type system in DesignScript is dynamic. DesignScript supports following prim
 </table>
 
 
-The default value of all other types is "null".
+If the language implementation supports FFI, the default value of all other imported FFI types is `null`.
 
 ### List
 
-In DesignScript, List is used to keep a collection of object. It is *immutable*, that is, we could use index to get value that stored in a list, but we should always call `Set(list, index, value)` to get a new list which stores new value at specified location.
+In DesignScript, List is used to keep a collection of object. It is *immutable*, that is, once it is defined, we can't add, delete or modify any element in the list, but we can call `Set(list, index, value)` to get a new list.
 
 #### Rank
 
-If a type has rank suffix, it declares a list. The number of "[]" specifies rank of this list. “[]..[]” specifies arbitrary rank. For example,
+If a parameter has rank suffix, it declares a list. The number of `[]` specifies rank of this list. `[]..[]` is for arbitrary rank. For example,
 
 ```
 number[]     // a number list whose rank is 1
@@ -198,20 +198,45 @@ Lists are dynamic. It is possible to index into any location of the list. If set
 ```
 x = {1, 2, 3};
 
-y = Set(x, 5, "foo")
-length = len(x);    // length == 6;
-v = y[5];           // v == "foo"
+y = Set(x, 5, "foo") // Set "foo" at position 5
+length = len(y);     // length == 6;
+v = y[5];            // v == "foo"
 ```
 
-When a dictionary is used in `in` clause of `for` loop, it returns all values associated with keys.
+When a dictionary is used in a function call, only values that indexed by non-negative integer key will be replicated over. Example:
+
+```
+def hello(x: string)
+{
+    return = "Hi, " + x;
+}
+xs = {0:"Tom", 1:"Jerry", "foo": "Dynamo"};
+r = hello(xs);  // r = {"Hi, Tom", "Hi, Jerry"}
+```
+
+There are two ways to iterate dictionary in `for` loop. Example:
+
+```
+xs = {0:"Tom", 1:"Jerry", "foo": "Dynamo"};
+[Imperative](xs)
+{
+    for k, v in xs {
+        ...
+    }
+
+    for v in xs {
+        ...
+    }
+}
+```
 
 ### Type conversion rules
 
-Following implicit type conversion rules specify the result of converting one type to another:
+Following type conversion rules specify the result of converting one type to the other:
 
 #### Non-list case
 
-"yes" means convertible, “no” means no convertible.
+"yes" means convertible, “no” means not convertible.
 
 <table>
   <tr>
@@ -320,14 +345,15 @@ Following implicit type conversion rules specify the result of converting one ty
 
 ## Variables
 
-A variable is storage location for a value. As DesignScript is dynamic, it is free to assign any kind of value to a variable. Variable in global scope is immutable. That is, a variable is only allowed to be assigned once. For example,
+A variable is storage location for a value. As DesignScript is dynamic, it is free to assign any kind of value to a variable. Variable in global scope is immutable. That is, a variable is only allowed to be assigned once. Example:
 
 ```
 a = 1;
 a = 2; // error: double assignment
 ```
 
-But a variable is mutable in imperative block. For example,
+But a variable is mutable in imperative block. Example:
+
 ```
 [Imperative]
 {
@@ -336,7 +362,7 @@ But a variable is mutable in imperative block. For example,
 }
 ```
 
-All variables should be defined before being used. For example,
+All variables should be defined before being used. Example:
 
 ```
 b = a; // error: "a" is not defined yet
@@ -347,10 +373,7 @@ a = 1;
 
 The scope of a defined variable in DesignScript is limited to a block or a function where it is defined and is not visible in any nested imperative block or any other function.
 
-To pass a variable to a nested imperative block, the variable should be explicitly captured in block's capture list. To pass a variable to a function, the variable should be passed as an argument. In either case, the variable will be copied to maintain its immutability.
-
-For example,
-
+To pass a variable to a nested imperative block, the variable should be explicitly captured in block's capture list. To pass a variable to a function, the variable should be passed as an argument. In either case, the variable will be copied to maintain its immutability. Example:
 
 ```
 x = 1;
@@ -395,13 +418,13 @@ StatementBlock =
     “{“ { Statement } “}”
 ```
 
-The return type of function is optional. By default the return type is var. If the return type is specified, type conversion may happen. It is not encouraged to specify return type unless it is necessary.
+The return type of function is optional. By default the return type is `var`. If the return type is specified, type conversion may happen. It is not encouraged to specify return type unless it is necessary.
 
 Function must be defined in top level block.
 
-For parameters, if their types are not specified, by default is var. The type of parameters should be carefully specified so that replication and replication guide will work as desired.
+For parameter, if its type is not specified, by default the type is `var`. The type of parameter should be carefully specified so that replication and replication guide would work as desired.
 
-For example:
+Example:
 
 ```
 def foo:var(x:number[]..[], y:number = 3)
@@ -412,18 +435,15 @@ def foo:var(x:number[]..[], y:number = 3)
 
 #### Default parameters
 
-Function declaration allows to have default parameter, but with one restriction: all default parameters should be the rightmost parameters.
-
-For example:
+Function declaration allows to have default arguments. For example:
 
 ```
-// it is valid because "y" and “z” are the rightmost default parameters
 def foo(x, y = 1, z = 2)
 {
     return = x + y + z;
 }
 
-// it is invalid because “x” is not the rightmost default parameter
+// Invalid
 def bar(x = 1, y, z = 2)
 {
     return = x + y + z;


### PR DESCRIPTION
Summary
  * Variable/Scope
  * Remove member access expression
  * Change "imperative language block" -> "imperative block", remove "associative"
  * Remove type conversion rules from number/string/etc to bool. Type conversion is stricter so that the following implicit type conversion will not be allowed:
    ```
    [Imperative] {
        x = {1, 2, 3};
        while (x) {
            ...
        }
    }
    ```

Updated spec: https://github.com/ke-yu/DesignScript/blob/update/LanguageSpec.md

@pboyer PTAL